### PR TITLE
Add zone classification system (Issue #20)

### DIFF
--- a/archivum-api/src/main/java/tech/zaisys/archivum/api/dto/FileDto.java
+++ b/archivum-api/src/main/java/tech/zaisys/archivum/api/dto/FileDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import tech.zaisys.archivum.api.enums.FileStatus;
+import tech.zaisys.archivum.api.enums.Zone;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -84,6 +85,11 @@ public class FileDto {
      * File status
      */
     private FileStatus status;
+
+    /**
+     * Classification zone
+     */
+    private Zone zone;
 
     /**
      * Whether this file is a duplicate

--- a/archivum-api/src/main/java/tech/zaisys/archivum/api/enums/Zone.java
+++ b/archivum-api/src/main/java/tech/zaisys/archivum/api/enums/Zone.java
@@ -1,0 +1,49 @@
+package tech.zaisys.archivum.api.enums;
+
+/**
+ * Classification zones for files and folders.
+ * Determines deduplication and archiving behavior.
+ */
+public enum Zone {
+    /**
+     * Photos, videos, music
+     * File dedup: YES, Folder dedup: YES
+     */
+    MEDIA,
+
+    /**
+     * PDFs, Office documents
+     * File dedup: YES, Folder dedup: YES
+     */
+    DOCUMENTS,
+
+    /**
+     * Ebooks, audiobooks
+     * File dedup: YES, Folder dedup: YES
+     */
+    BOOKS,
+
+    /**
+     * Installers, applications, games
+     * File dedup: NO (preserve DLLs), Folder dedup: YES
+     */
+    SOFTWARE,
+
+    /**
+     * Full backup archives
+     * File dedup: NO, Folder dedup: YES
+     */
+    BACKUP,
+
+    /**
+     * Source code repositories
+     * File dedup: NO, Folder dedup: YES
+     */
+    CODE,
+
+    /**
+     * Unclassified content needing manual review
+     * File dedup: NO, Folder dedup: NO
+     */
+    UNKNOWN
+}

--- a/archivum-server/src/main/java/tech/zaisys/archivum/server/controller/FileController.java
+++ b/archivum-server/src/main/java/tech/zaisys/archivum/server/controller/FileController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import tech.zaisys.archivum.api.dto.FileBatchDto;
 import tech.zaisys.archivum.api.dto.FileDto;
+import tech.zaisys.archivum.api.enums.Zone;
 import tech.zaisys.archivum.server.service.FileBatchResult;
 import tech.zaisys.archivum.server.service.FileService;
 
@@ -110,5 +111,30 @@ public class FileController {
 
         List<FileDto> duplicates = fileService.findDuplicates(id);
         return ResponseEntity.ok(duplicates);
+    }
+
+    /**
+     * Update the zone classification for a file.
+     *
+     * PATCH /api/files/{id}/zone
+     *
+     * @param id File ID
+     * @param request Request body containing the new zone
+     * @return Updated file DTO
+     */
+    @PatchMapping("/{id}/zone")
+    public ResponseEntity<FileDto> updateZone(
+            @PathVariable UUID id,
+            @RequestBody Map<String, String> request) {
+        log.info("PATCH /api/files/{}/zone - zone={}", id, request.get("zone"));
+
+        try {
+            Zone zone = Zone.valueOf(request.get("zone"));
+            FileDto updated = fileService.updateZone(id, zone);
+            return ResponseEntity.ok(updated);
+        } catch (IllegalArgumentException e) {
+            log.error("Invalid zone or file not found: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
+        }
     }
 }

--- a/archivum-server/src/main/java/tech/zaisys/archivum/server/domain/ScannedFile.java
+++ b/archivum-server/src/main/java/tech/zaisys/archivum/server/domain/ScannedFile.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import tech.zaisys.archivum.api.dto.ExifMetadata;
 import tech.zaisys.archivum.api.enums.FileStatus;
+import tech.zaisys.archivum.api.enums.Zone;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -71,6 +72,11 @@ public class ScannedFile {
     @Column(nullable = false, length = 50)
     @Builder.Default
     private FileStatus status = FileStatus.HASHED;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 50)
+    @Builder.Default
+    private Zone zone = Zone.UNKNOWN;
 
     @Column(name = "is_duplicate", nullable = false)
     @Builder.Default

--- a/archivum-server/src/main/java/tech/zaisys/archivum/server/mapper/FileMapper.java
+++ b/archivum-server/src/main/java/tech/zaisys/archivum/server/mapper/FileMapper.java
@@ -35,6 +35,7 @@ public class FileMapper {
             .mimeType(dto.getMimeType())
             .exifMetadata(dto.getExif())
             .status(dto.getStatus())
+            .zone(dto.getZone())
             .isDuplicate(dto.getIsDuplicate() != null ? dto.getIsDuplicate() : false)
             .scannedAt(dto.getScannedAt())
             .build();
@@ -74,6 +75,7 @@ public class FileMapper {
             .mimeType(entity.getMimeType())
             .exif(entity.getExifMetadata())
             .status(entity.getStatus())
+            .zone(entity.getZone())
             .isDuplicate(entity.getIsDuplicate())
             .originalFileId(entity.getOriginalFile() != null ?
                 entity.getOriginalFile().getId() : null)

--- a/archivum-server/src/main/java/tech/zaisys/archivum/server/service/FileService.java
+++ b/archivum-server/src/main/java/tech/zaisys/archivum/server/service/FileService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tech.zaisys.archivum.api.dto.FileBatchDto;
 import tech.zaisys.archivum.api.dto.FileDto;
+import tech.zaisys.archivum.api.enums.Zone;
 import tech.zaisys.archivum.server.domain.ScannedFile;
 import tech.zaisys.archivum.server.domain.Source;
 import tech.zaisys.archivum.server.mapper.FileMapper;
@@ -163,5 +164,25 @@ public class FileService {
         return duplicates.stream()
             .map(fileMapper::toDto)
             .toList();
+    }
+
+    /**
+     * Update the zone classification for a file.
+     *
+     * @param fileId File ID
+     * @param zone New zone
+     * @return Updated file DTO
+     */
+    @Transactional
+    public FileDto updateZone(UUID fileId, Zone zone) {
+        log.info("Updating zone for file {} to {}", fileId, zone);
+
+        ScannedFile file = fileRepository.findById(fileId)
+            .orElseThrow(() -> new IllegalArgumentException("File not found: " + fileId));
+
+        file.setZone(zone);
+        ScannedFile saved = fileRepository.save(file);
+
+        return fileMapper.toDto(saved);
     }
 }

--- a/archivum-server/src/main/resources/db/migration/V006__add_zone_column.sql
+++ b/archivum-server/src/main/resources/db/migration/V006__add_zone_column.sql
@@ -1,0 +1,8 @@
+-- Add zone column to scanned_file table
+ALTER TABLE scanned_file
+ADD COLUMN zone VARCHAR(50) DEFAULT 'UNKNOWN';
+
+-- Update existing rows to have UNKNOWN zone
+UPDATE scanned_file
+SET zone = 'UNKNOWN'
+WHERE zone IS NULL;

--- a/archivum-ui/src/api/files.ts
+++ b/archivum-ui/src/api/files.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ScannedFile, FileBatch, FileBatchResult } from '../types/file';
+import type { Zone } from '../types/zone';
 
 const API_BASE = '/api/files';
 
@@ -70,6 +71,23 @@ export async function getFileDuplicates(fileId: string): Promise<ScannedFile[]> 
   const response = await fetch(`${API_BASE}/${fileId}/duplicates`);
   if (!response.ok) {
     throw new Error(`Failed to fetch duplicates for file ${fileId}`);
+  }
+  return response.json();
+}
+
+/**
+ * Update the zone classification for a file.
+ */
+export async function updateFileZone(fileId: string, zone: Zone): Promise<ScannedFile> {
+  const response = await fetch(`${API_BASE}/${fileId}/zone`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ zone })
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to update zone for file ${fileId}`);
   }
   return response.json();
 }

--- a/archivum-ui/src/types/file.ts
+++ b/archivum-ui/src/types/file.ts
@@ -2,6 +2,8 @@
  * Type definitions for File domain.
  */
 
+import { Zone } from './zone';
+
 export enum FileStatus {
   DISCOVERED = 'DISCOVERED',
   HASHED = 'HASHED',
@@ -38,6 +40,7 @@ export type ScannedFile = {
   mimeType?: string;
   exif?: ExifData;
   status: FileStatus;
+  zone?: Zone;
   isDuplicate: boolean;
   originalFileId?: string;
   scannedAt: string;

--- a/archivum-ui/src/types/zone.ts
+++ b/archivum-ui/src/types/zone.ts
@@ -1,0 +1,32 @@
+/**
+ * Classification zones for files and folders.
+ */
+export enum Zone {
+  MEDIA = 'MEDIA',
+  DOCUMENTS = 'DOCUMENTS',
+  BOOKS = 'BOOKS',
+  SOFTWARE = 'SOFTWARE',
+  BACKUP = 'BACKUP',
+  CODE = 'CODE',
+  UNKNOWN = 'UNKNOWN'
+}
+
+export const ZONE_LABELS: Record<Zone, string> = {
+  [Zone.MEDIA]: 'Media',
+  [Zone.DOCUMENTS]: 'Documents',
+  [Zone.BOOKS]: 'Books',
+  [Zone.SOFTWARE]: 'Software',
+  [Zone.BACKUP]: 'Backup',
+  [Zone.CODE]: 'Code',
+  [Zone.UNKNOWN]: 'Unknown'
+};
+
+export const ZONE_COLORS: Record<Zone, string> = {
+  [Zone.MEDIA]: 'bg-purple-100 text-purple-800',
+  [Zone.DOCUMENTS]: 'bg-blue-100 text-blue-800',
+  [Zone.BOOKS]: 'bg-green-100 text-green-800',
+  [Zone.SOFTWARE]: 'bg-orange-100 text-orange-800',
+  [Zone.BACKUP]: 'bg-gray-100 text-gray-800',
+  [Zone.CODE]: 'bg-cyan-100 text-cyan-800',
+  [Zone.UNKNOWN]: 'bg-red-100 text-red-800'
+};


### PR DESCRIPTION
## Summary

Implements backend and API foundation for zone classification (Issue #20).

## Changes

### Backend
- ✅ Created `Zone` enum (MEDIA, DOCUMENTS, BOOKS, SOFTWARE, BACKUP, CODE, UNKNOWN)
- ✅ Added `zone` field to `ScannedFile` entity (defaults to UNKNOWN)
- ✅ Database migration V006 to add zone column
- ✅ API endpoint: `PATCH /api/files/{id}/zone` to update file zone
- ✅ Service method: `FileService.updateZone()`
- ✅ Updated `FileMapper` to include zone in DTO mappings

### Frontend
- ✅ Created `Zone` type with labels and color constants
- ✅ Added `zone` field to `ScannedFile` type
- ✅ API function: `updateFileZone(fileId, zone)`

### Database
- Migration adds `zone` column with default 'UNKNOWN'
- Existing files will be set to UNKNOWN zone

## Testing
- ✅ Backend builds successfully
- ✅ Frontend builds successfully
- ✅ Migration script validated

## Next Steps
UI components for zone selection/display will be added in a follow-up PR.

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)