### PR TITLE
Add SOFTWARE_LIB zone classification (#14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,7 @@ Files are categorized into zones that determine deduplication behavior:
 | SOFTWARE | No | Yes | Installers, apps (preserve DLLs) |
 | BACKUP | No | Yes | Full backup sets |
 | CODE | No | Yes | Source code repos |
+| SOFTWARE_LIB | Yes | Yes | Libraries (.m2, .venv, node_modules) - can be redownloaded |
 | UNKNOWN | No | No | Needs manual classification |
 
 **Manual Zone Classification:**

--- a/archivum-api/src/main/java/tech/zaisys/archivum/api/enums/Zone.java
+++ b/archivum-api/src/main/java/tech/zaisys/archivum/api/enums/Zone.java
@@ -42,6 +42,13 @@ public enum Zone {
     CODE,
 
     /**
+     * Software libraries (Maven .m2, Python .venv, node_modules, etc.)
+     * File dedup: YES, Folder dedup: YES
+     * Note: Usually can be ignored/redownloaded from internet
+     */
+    SOFTWARE_LIB,
+
+    /**
      * Unclassified content needing manual review
      * File dedup: NO, Folder dedup: NO
      */

--- a/archivum-ui/src/types/zone.ts
+++ b/archivum-ui/src/types/zone.ts
@@ -8,6 +8,7 @@ export enum Zone {
   SOFTWARE = 'SOFTWARE',
   BACKUP = 'BACKUP',
   CODE = 'CODE',
+  SOFTWARE_LIB = 'SOFTWARE_LIB',
   UNKNOWN = 'UNKNOWN'
 }
 
@@ -18,6 +19,7 @@ export const ZONE_LABELS: Record<Zone, string> = {
   [Zone.SOFTWARE]: 'Software',
   [Zone.BACKUP]: 'Backup',
   [Zone.CODE]: 'Code',
+  [Zone.SOFTWARE_LIB]: 'Software Lib',
   [Zone.UNKNOWN]: 'Unknown'
 };
 
@@ -28,5 +30,6 @@ export const ZONE_COLORS: Record<Zone, string> = {
   [Zone.SOFTWARE]: 'bg-orange-100 text-orange-800',
   [Zone.BACKUP]: 'bg-gray-100 text-gray-800',
   [Zone.CODE]: 'bg-cyan-100 text-cyan-800',
+  [Zone.SOFTWARE_LIB]: 'bg-amber-100 text-amber-800',
   [Zone.UNKNOWN]: 'bg-red-100 text-red-800'
 };


### PR DESCRIPTION
## Summary

This PR adds the SOFTWARE_LIB zone classification to support organizing software library folders (Maven .m2, Python .venv, node_modules, etc.) that can be safely deduplicated and are typically redownloadable from the internet.

## Changes

- **Backend**: Added SOFTWARE_LIB enum value to Zone.java with documentation
- **Frontend**: Added SOFTWARE_LIB to TypeScript zone.ts with "Software Lib" label and amber color styling
- **Documentation**: Updated CLAUDE.md zones table to include SOFTWARE_LIB zone

## Zone Behavior

- **File deduplication**: YES
- **Folder deduplication**: YES
- **Use case**: Maven .m2, Python .venv, node_modules, and other library caches

## Testing

- Existing test `SourceControllerFolderZoneTest.shouldUpdateFolderZoneForAllValidZones()` loops through all Zone enum values, automatically covering SOFTWARE_LIB
- Verified no new test failures introduced (9 pre-existing test failures on main branch remain unchanged)

## Coding Principles Checklist

- ✅ Keep methods short - No new methods, only enum values added
- ✅ Single responsibility - Focused change for one zone type
- ✅ Design for testability - Existing tests cover all zones
- ✅ Clear naming - SOFTWARE_LIB clearly describes software libraries
- ✅ Good documentation - Clear comment explaining what SOFTWARE_LIB includes
- ✅ Immutability - TypeScript uses immutable Record types
- ✅ Documentation updated - CLAUDE.md zones table updated

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)