### PR TITLE
Add View Source link to Code Project cards (#15)

### DIFF
--- a/archivum-ui/src/components/CodeProjectList.tsx
+++ b/archivum-ui/src/components/CodeProjectList.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useCodeProjects } from '../hooks/useCodeProjects';
 import { ProjectType, type CodeProject } from '../types/codeProject';
 import { ProjectDetailsModal } from './ProjectDetailsModal';
@@ -143,6 +144,13 @@ function ProjectCard({ project, getIcon, getColor, formatBytes, onProjectClick }
         <p className="truncate" title={project.rootPath}>
           📂 {project.rootPath}
         </p>
+        <Link
+          to={`/sources/${project.sourceId}`}
+          className="text-xs text-blue-600 hover:text-blue-800 hover:underline inline-flex items-center gap-1 mt-1"
+          onClick={(e) => e.stopPropagation()}
+        >
+          View Source →
+        </Link>
       </div>
 
       <div className="grid grid-cols-2 gap-2 text-sm">


### PR DESCRIPTION
## Summary

This PR adds a "View Source →" link to Code Project cards that navigates users directly to the corresponding Source details page. This improves navigation by allowing users to quickly view the source disk/location where the code project was found.

## Changes

- **Import**: Added `Link` from `react-router-dom` to CodeProjectList component
- **UI**: Added "View Source →" link below the root path in ProjectCard
- **Navigation**: Link navigates to `/sources/{sourceId}` using the project's `sourceId`
- **UX**: Used `stopPropagation()` to prevent modal opening when clicking the link
- **Styling**: Blue link color with hover underline for clear interactivity

## User Flow

Before:
- Users could only see project details modal by clicking the type badge
- No direct way to navigate to the source

After:
- Click "View Source →" link to navigate to source details page
- Click type badge to view project details modal (existing behavior preserved)

## Testing

- ✅ Built successfully with `npm run build`
- ✅ TypeScript compilation passed
- ✅ No errors or warnings

## Coding Principles Checklist

- ✅ Functional components - Using functional component
- ✅ Named exports - Using named exports
- ✅ Types over interfaces - Using type for CodeProject
- ✅ Clear naming - "View Source" is descriptive
- ✅ Use established libraries - Using React Router's Link component
- ✅ Follows existing patterns - Consistent with codebase styling

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)