### PR TITLE
Fix broken build, enable Docker-gated tests, fix source_type default

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,17 +1,59 @@
 # Archivum Development Plan
 
-**Last Updated:** 2025-11-28
-**Current Phase:** Scanner MVP
-**Active Milestone:** Milestone 3 - Advanced Metadata (ready to start)
+**Last Updated:** 2026-07-20
+**Current Phase:** Migration System (server + UI in active use)
+**Active Milestone:** Migration advanced features (Milestone 5) — not yet started
 
 ---
 
 ## Status Overview
 
-✅ Completed: 3 milestones
-🔄 In Progress: None (ready to start Milestone 3)
-📋 Upcoming: 3 milestones (implementation)
-⏳ Future: Server, UI, advanced features
+All four modules exist and are working: `archivum-api`, `archivum-scanner`,
+`archivum-server`, `archivum-ui`. `./gradlew build` is **green** (all modules
+compile, all tests pass).
+
+✅ Scanner MVP: delivered (core scanning, hashing, metadata, upload, code-project detection, zones)
+✅ Server: operational (REST API, PostgreSQL/Flyway, ingestion, dedup, destinations)
+✅ UI: operational (sources, files, code projects, destinations)
+✅ Migration System: Milestones 1–4 delivered (disk tracking, NAS migration, destination scanning, warehouse)
+🔄 In Progress: none tracked
+📋 Next: Migration advanced features (git archive, bi-directional refinements)
+
+> **Historical note:** The milestone list below (M0–M5) describes the original
+> **Scanner MVP** plan from Nov 2025. Development since then moved onto the
+> **Migration System** track — see "Migration System Status" below and
+> `docs/IMPLEMENTATION_PLAN.md`. The scanner M3–M5 items were largely absorbed
+> into later work; treat them as historical rather than the live backlog.
+
+---
+
+## Build Environment
+
+- **Requires JDK 21** (Temurin 21 verified). A Java 8 or JRE-only 21 will fail:
+  the Gradle build needs a full JDK 21 *with* `javac`, and the Sonar plugin
+  needs Java 11+ just to configure.
+- Build/test: `./gradlew build` from the repo root.
+
+---
+
+## Migration System Status
+
+Tracked in `docs/IMPLEMENTATION_PLAN.md` and `docs/MIGRATION_WORKFLOW.md`.
+Schema at **V019** (`db/migration/`).
+
+| Milestone | Description | Status |
+|-----------|-------------|--------|
+| M1 | Foundation & disk tracking (offline workflow, source/file states) | ✅ Delivered |
+| M2 | Basic NAS migration | ✅ Delivered |
+| M3 | Destination scanning (baseline / pinning already-organized files) | ✅ Delivered |
+| M4 | Warehouse migration | ✅ Delivered |
+| — | Destination management system (V018, disk-space monitoring) | ✅ Delivered |
+| — | `ignore_for_migration` flag (V019) | ✅ Delivered |
+| M5 | Advanced features (git archive, bi-directional refinements) | 📋 Not started |
+
+**Note (2026-07-20):** `main` was found broken — `FileService` (ignore-for-migration
+feature) called three `ScannedFileRepository` methods that were never added. Fixed by
+adding the derived-query methods + `Source` import; build is green again.
 
 ---
 
@@ -276,19 +318,20 @@ The following features are **not included in MVP** and will be implemented later
 
 ---
 
-## Timeline Summary
+## Timeline Summary (Scanner MVP — historical)
 
 | Milestone | Duration | Status | Started | Completed |
 |-----------|----------|--------|---------|-----------|
 | M0: Shared API | 3h | ✅ Complete | Nov 27 | Nov 27 |
 | M1: Documentation | 6h | ✅ Complete | Nov 28 | Nov 28 |
 | M2: Foundation & Core | 10h | ✅ Complete | Nov 28 | Nov 28 |
-| M3: Advanced Metadata | 8h | 📋 Next | TBD | TBD |
-| M4: Hierarchy & Archives | 10h | 📋 Upcoming | TBD | TBD |
-| M5: Copy & Polish | 8h | 📋 Upcoming | TBD | TBD |
-| **Total** | **45h** | **42% done** | | |
+| M3: Advanced Metadata | 8h | ✅ Absorbed into later work | — | — |
+| M4: Hierarchy & Archives | 10h | ✅ Absorbed into later work | — | — |
+| M5: Copy & Polish | 8h | ✅ Absorbed into later work | — | — |
 
-**Estimated Completion:** 3-4 weeks (assuming ~8-10h/week)
+The project has since moved well beyond the Scanner MVP: server, UI, and the
+Migration System (Milestones 1–4) are all delivered. See "Migration System
+Status" above for the live status.
 
 ---
 
@@ -395,4 +438,4 @@ After every 2-3 milestones, we do a quick retrospective:
 
 **Maintained by:** Haris + Claude
 **Project Start:** November 2025
-**Last Review:** November 28, 2025
+**Last Review:** July 20, 2026

--- a/archivum-server/src/main/java/tech/zaisys/archivum/server/repository/ScannedFileRepository.java
+++ b/archivum-server/src/main/java/tech/zaisys/archivum/server/repository/ScannedFileRepository.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import tech.zaisys.archivum.api.enums.FileState;
 import tech.zaisys.archivum.api.enums.FileStatus;
 import tech.zaisys.archivum.server.domain.ScannedFile;
+import tech.zaisys.archivum.server.domain.Source;
 
 import java.util.List;
 import java.util.Optional;
@@ -207,4 +208,32 @@ public interface ScannedFileRepository extends JpaRepository<ScannedFile, UUID> 
      */
     @Query("SELECT COALESCE(SUM(f.size), 0) FROM ScannedFile f WHERE f.source.id = :sourceId AND f.path LIKE CONCAT(:folderPath, '%')")
     long sumSizeBySourceIdAndPathStartingWith(@Param("sourceId") UUID sourceId, @Param("folderPath") String folderPath);
+
+    /**
+     * Find all files for a source whose path starts with the given prefix.
+     * Used to cascade migration-ignore over a folder's contents.
+     *
+     * @param source Source
+     * @param pathPrefix Path prefix (e.g., "photos/2020/")
+     * @return List of files under the prefix
+     */
+    List<ScannedFile> findBySourceAndPathStartingWith(Source source, String pathPrefix);
+
+    /**
+     * Find a file by source and exact path.
+     *
+     * @param source Source
+     * @param path Exact file path
+     * @return Optional file
+     */
+    Optional<ScannedFile> findBySourceAndPath(Source source, String path);
+
+    /**
+     * Find all files for a source by their ignore-for-migration flag.
+     *
+     * @param source Source
+     * @param ignoreForMigration Flag value
+     * @return List of matching files
+     */
+    List<ScannedFile> findBySourceAndIgnoreForMigration(Source source, boolean ignoreForMigration);
 }

--- a/archivum-server/src/main/java/tech/zaisys/archivum/server/repository/ScannedFileRepository.java
+++ b/archivum-server/src/main/java/tech/zaisys/archivum/server/repository/ScannedFileRepository.java
@@ -220,15 +220,6 @@ public interface ScannedFileRepository extends JpaRepository<ScannedFile, UUID> 
     List<ScannedFile> findBySourceAndPathStartingWith(Source source, String pathPrefix);
 
     /**
-     * Find a file by source and exact path.
-     *
-     * @param source Source
-     * @param path Exact file path
-     * @return Optional file
-     */
-    Optional<ScannedFile> findBySourceAndPath(Source source, String path);
-
-    /**
      * Find all files for a source by their ignore-for-migration flag.
      *
      * @param source Source

--- a/archivum-server/src/main/java/tech/zaisys/archivum/server/service/FileService.java
+++ b/archivum-server/src/main/java/tech/zaisys/archivum/server/service/FileService.java
@@ -257,7 +257,7 @@ public class FileService {
         List<ScannedFile> filesToIgnore = fileRepository.findBySourceAndPathStartingWith(source, pathPrefix);
 
         // Also check if the folder itself exists as a file entry
-        fileRepository.findBySourceAndPath(source, folderPath)
+        fileRepository.findBySourceIdAndPath(sourceId, folderPath)
             .ifPresent(filesToIgnore::add);
 
         // Mark all files as ignored

--- a/archivum-server/src/main/java/tech/zaisys/archivum/server/service/SourceService.java
+++ b/archivum-server/src/main/java/tech/zaisys/archivum/server/service/SourceService.java
@@ -8,6 +8,7 @@ import tech.zaisys.archivum.api.dto.CompleteScanRequest;
 import tech.zaisys.archivum.api.dto.CreateSourceRequest;
 import tech.zaisys.archivum.api.dto.SourceDto;
 import tech.zaisys.archivum.api.enums.ScanStatus;
+import tech.zaisys.archivum.api.enums.SourceScanType;
 import tech.zaisys.archivum.server.domain.Source;
 import tech.zaisys.archivum.server.repository.SourceRepository;
 
@@ -54,7 +55,7 @@ public class SourceService {
             .lastSeen(request.getLastSeen())
             .sourceScanType(request.getSourceScanType() != null
                 ? request.getSourceScanType()
-                : tech.zaisys.archivum.api.enums.SourceScanType.DISCOVERY)
+                : SourceScanType.DISCOVERY)
             .build();
 
         // Set parent if specified

--- a/archivum-server/src/main/java/tech/zaisys/archivum/server/service/SourceService.java
+++ b/archivum-server/src/main/java/tech/zaisys/archivum/server/service/SourceService.java
@@ -52,7 +52,9 @@ public class SourceService {
             .diskState(request.getDiskState())
             .mountPoint(request.getMountPoint())
             .lastSeen(request.getLastSeen())
-            .sourceScanType(request.getSourceScanType())
+            .sourceScanType(request.getSourceScanType() != null
+                ? request.getSourceScanType()
+                : tech.zaisys.archivum.api.enums.SourceScanType.DISCOVERY)
             .build();
 
         // Set parent if specified

--- a/archivum-server/src/test/java/tech/zaisys/archivum/server/integration/FileIngestionIntegrationTest.java
+++ b/archivum-server/src/test/java/tech/zaisys/archivum/server/integration/FileIngestionIntegrationTest.java
@@ -37,7 +37,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * TODO: Enable when Docker environment is properly configured for tests
  */
-@org.junit.jupiter.api.Disabled("Requires Docker - enable when CI/CD environment is configured")
 @SpringBootTest
 @AutoConfigureMockMvc
 @Testcontainers

--- a/archivum-server/src/test/java/tech/zaisys/archivum/server/integration/FileIngestionIntegrationTest.java
+++ b/archivum-server/src/test/java/tech/zaisys/archivum/server/integration/FileIngestionIntegrationTest.java
@@ -34,8 +34,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Integration tests for file ingestion endpoint with real PostgreSQL database.
  * These tests verify that the schema can handle realistic data.
- *
- * TODO: Enable when Docker environment is properly configured for tests
  */
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/archivum-server/src/test/java/tech/zaisys/archivum/server/integration/SourceCreationIntegrationTest.java
+++ b/archivum-server/src/test/java/tech/zaisys/archivum/server/integration/SourceCreationIntegrationTest.java
@@ -35,7 +35,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * TODO: Enable when Docker environment is properly configured for tests
  */
-@org.junit.jupiter.api.Disabled("Requires Docker - enable when CI/CD environment is configured")
 @SpringBootTest
 @AutoConfigureMockMvc
 @Testcontainers

--- a/archivum-server/src/test/java/tech/zaisys/archivum/server/integration/SourceCreationIntegrationTest.java
+++ b/archivum-server/src/test/java/tech/zaisys/archivum/server/integration/SourceCreationIntegrationTest.java
@@ -32,8 +32,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Integration tests for source creation endpoint with real PostgreSQL database.
  * Tests that all SourceScanType enum values can be persisted correctly.
- *
- * TODO: Enable when Docker environment is properly configured for tests
  */
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/archivum-server/src/test/java/tech/zaisys/archivum/server/repository/FolderZoneRepositoryTest.java
+++ b/archivum-server/src/test/java/tech/zaisys/archivum/server/repository/FolderZoneRepositoryTest.java
@@ -24,8 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration tests for FolderZoneRepository using Testcontainers.
- *
- * TODO: Enable when Docker environment is properly configured for tests
  */
 @DataJpaTest
 @Testcontainers

--- a/archivum-server/src/test/java/tech/zaisys/archivum/server/repository/FolderZoneRepositoryTest.java
+++ b/archivum-server/src/test/java/tech/zaisys/archivum/server/repository/FolderZoneRepositoryTest.java
@@ -27,7 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * TODO: Enable when Docker environment is properly configured for tests
  */
-@org.junit.jupiter.api.Disabled("Requires Docker - enable when CI/CD environment is configured")
 @DataJpaTest
 @Testcontainers
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -45,7 +44,7 @@ class FolderZoneRepositoryTest {
         registry.add("spring.datasource.url", postgres::getJdbcUrl);
         registry.add("spring.datasource.username", postgres::getUsername);
         registry.add("spring.datasource.password", postgres::getPassword);
-        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
     }
 
     @Autowired

--- a/archivum-server/src/test/java/tech/zaisys/archivum/server/repository/ScannedFileRepositoryTest.java
+++ b/archivum-server/src/test/java/tech/zaisys/archivum/server/repository/ScannedFileRepositoryTest.java
@@ -413,9 +413,10 @@ class ScannedFileRepositoryTest {
 
     @Test
     void testFindBySourceAndPathStartingWith() {
-        // Given - two files under photos/, one under documents/
+        // Given - two files under photos/, plus a sibling folder and an unrelated one
         scannedFileRepository.save(testFile); // photos/vacation.jpg
         scannedFileRepository.save(fileAt("photos/sub/beach.jpg", "beach_hash" + "0".repeat(54)));
+        scannedFileRepository.save(fileAt("photos2/other.jpg", "photos2_ha" + "0".repeat(54)));
         scannedFileRepository.save(fileAt("documents/report.pdf", "report_hash" + "0".repeat(53)));
         entityManager.flush();
 
@@ -423,25 +424,10 @@ class ScannedFileRepositoryTest {
         List<ScannedFile> underPhotos =
             scannedFileRepository.findBySourceAndPathStartingWith(testSource, "photos/");
 
-        // Then - only the two files under photos/, not the document
+        // Then - only the two files under photos/; the "photos2/" sibling is excluded
+        // by the trailing slash, and the unrelated document is excluded too
         assertEquals(2, underPhotos.size());
         assertTrue(underPhotos.stream().allMatch(f -> f.getPath().startsWith("photos/")));
-    }
-
-    @Test
-    void testFindBySourceAndPath() {
-        // Given
-        scannedFileRepository.save(testFile);
-        entityManager.flush();
-
-        // When
-        Optional<ScannedFile> found =
-            scannedFileRepository.findBySourceAndPath(testSource, "photos/vacation.jpg");
-
-        // Then
-        assertTrue(found.isPresent());
-        assertEquals("vacation.jpg", found.get().getName());
-        assertTrue(scannedFileRepository.findBySourceAndPath(testSource, "photos/missing.jpg").isEmpty());
     }
 
     @Test

--- a/archivum-server/src/test/java/tech/zaisys/archivum/server/repository/ScannedFileRepositoryTest.java
+++ b/archivum-server/src/test/java/tech/zaisys/archivum/server/repository/ScannedFileRepositoryTest.java
@@ -23,6 +23,7 @@ import tech.zaisys.archivum.server.domain.Source;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -85,6 +86,7 @@ class ScannedFileRepositoryTest {
 
         // Create test file
         testFile = ScannedFile.builder()
+            .id(UUID.randomUUID())
             .source(testSource)
             .path("photos/vacation.jpg")
             .name("vacation.jpg")
@@ -170,6 +172,7 @@ class ScannedFileRepositoryTest {
 
         // When/Then - Attempting to save duplicate path for same source
         ScannedFile duplicate = ScannedFile.builder()
+            .id(UUID.randomUUID())
             .source(testSource)
             .path("photos/vacation.jpg") // Same path
             .name("vacation.jpg")
@@ -191,6 +194,7 @@ class ScannedFileRepositoryTest {
         scannedFileRepository.save(testFile);
 
         ScannedFile file2 = ScannedFile.builder()
+            .id(UUID.randomUUID())
             .source(testSource)
             .path("photos/beach.jpg")
             .name("beach.jpg")
@@ -231,6 +235,7 @@ class ScannedFileRepositoryTest {
         scannedFileRepository.save(testFile);
 
         ScannedFile duplicate = ScannedFile.builder()
+            .id(UUID.randomUUID())
             .source(testSource)
             .path("photos/vacation_copy.jpg")
             .name("vacation_copy.jpg")
@@ -281,6 +286,7 @@ class ScannedFileRepositoryTest {
         scannedFileRepository.save(testFile);
 
         ScannedFile duplicateFile = ScannedFile.builder()
+            .id(UUID.randomUUID())
             .source(testSource)
             .path("photos/dup.jpg")
             .name("dup.jpg")
@@ -309,6 +315,7 @@ class ScannedFileRepositoryTest {
         scannedFileRepository.save(testFile);
 
         ScannedFile duplicateFile = ScannedFile.builder()
+            .id(UUID.randomUUID())
             .source(testSource)
             .path("photos/dup.jpg")
             .name("dup.jpg")
@@ -335,6 +342,7 @@ class ScannedFileRepositoryTest {
         scannedFileRepository.save(testFile);
 
         ScannedFile pdfFile = ScannedFile.builder()
+            .id(UUID.randomUUID())
             .source(testSource)
             .path("documents/report.pdf")
             .name("report.pdf")
@@ -364,10 +372,11 @@ class ScannedFileRepositoryTest {
         // When
         sourceRepository.delete(testSource);
         entityManager.flush();
+        entityManager.clear(); // Evict cached entity so findById hits the DB
 
         // Then
         Optional<ScannedFile> found = scannedFileRepository.findById(saved.getId());
-        assertFalse(found.isPresent()); // File should be deleted when source is deleted
+        assertFalse(found.isPresent()); // File should be deleted when source is deleted (ON DELETE CASCADE)
     }
 
     @Test
@@ -377,6 +386,7 @@ class ScannedFileRepositoryTest {
         entityManager.flush();
 
         ScannedFile duplicate = ScannedFile.builder()
+            .id(UUID.randomUUID())
             .source(testSource)
             .path("photos/vacation_copy.jpg")
             .name("vacation_copy.jpg")
@@ -399,5 +409,72 @@ class ScannedFileRepositoryTest {
         assertTrue(foundDuplicate.get().getIsDuplicate());
         assertNotNull(foundDuplicate.get().getOriginalFile());
         assertEquals(original.getId(), foundDuplicate.get().getOriginalFile().getId());
+    }
+
+    @Test
+    void testFindBySourceAndPathStartingWith() {
+        // Given - two files under photos/, one under documents/
+        scannedFileRepository.save(testFile); // photos/vacation.jpg
+        scannedFileRepository.save(fileAt("photos/sub/beach.jpg", "beach_hash" + "0".repeat(54)));
+        scannedFileRepository.save(fileAt("documents/report.pdf", "report_hash" + "0".repeat(53)));
+        entityManager.flush();
+
+        // When
+        List<ScannedFile> underPhotos =
+            scannedFileRepository.findBySourceAndPathStartingWith(testSource, "photos/");
+
+        // Then - only the two files under photos/, not the document
+        assertEquals(2, underPhotos.size());
+        assertTrue(underPhotos.stream().allMatch(f -> f.getPath().startsWith("photos/")));
+    }
+
+    @Test
+    void testFindBySourceAndPath() {
+        // Given
+        scannedFileRepository.save(testFile);
+        entityManager.flush();
+
+        // When
+        Optional<ScannedFile> found =
+            scannedFileRepository.findBySourceAndPath(testSource, "photos/vacation.jpg");
+
+        // Then
+        assertTrue(found.isPresent());
+        assertEquals("vacation.jpg", found.get().getName());
+        assertTrue(scannedFileRepository.findBySourceAndPath(testSource, "photos/missing.jpg").isEmpty());
+    }
+
+    @Test
+    void testFindBySourceAndIgnoreForMigration() {
+        // Given - one ignored file, one not ignored
+        testFile.setIgnoreForMigration(true);
+        scannedFileRepository.save(testFile);
+        scannedFileRepository.save(fileAt("photos/keep.jpg", "keep_hash" + "0".repeat(55)));
+        entityManager.flush();
+
+        // When
+        List<ScannedFile> ignored =
+            scannedFileRepository.findBySourceAndIgnoreForMigration(testSource, true);
+        List<ScannedFile> notIgnored =
+            scannedFileRepository.findBySourceAndIgnoreForMigration(testSource, false);
+
+        // Then
+        assertEquals(1, ignored.size());
+        assertEquals("photos/vacation.jpg", ignored.get(0).getPath());
+        assertEquals(1, notIgnored.size());
+        assertEquals("photos/keep.jpg", notIgnored.get(0).getPath());
+    }
+
+    private ScannedFile fileAt(String path, String sha256) {
+        return ScannedFile.builder()
+            .id(UUID.randomUUID())
+            .source(testSource)
+            .path(path)
+            .name(path.substring(path.lastIndexOf('/') + 1))
+            .extension("jpg")
+            .size(1024000L)
+            .sha256(sha256)
+            .scannedAt(Instant.now())
+            .build();
     }
 }

--- a/archivum-server/src/test/java/tech/zaisys/archivum/server/service/FileServiceTest.java
+++ b/archivum-server/src/test/java/tech/zaisys/archivum/server/service/FileServiceTest.java
@@ -537,7 +537,7 @@ class FileServiceTest {
         when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(testSource));
         when(fileRepository.findBySourceAndPathStartingWith(testSource, "photos/"))
             .thenReturn(new ArrayList<>(List.of(alreadyIgnored, toIgnore)));
-        when(fileRepository.findBySourceAndPath(testSource, "photos"))
+        when(fileRepository.findBySourceIdAndPath(sourceId, "photos"))
             .thenReturn(Optional.empty());
 
         // When
@@ -563,7 +563,7 @@ class FileServiceTest {
         when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(testSource));
         when(fileRepository.findBySourceAndPathStartingWith(testSource, "photos/"))
             .thenReturn(new ArrayList<>());
-        when(fileRepository.findBySourceAndPath(testSource, "photos"))
+        when(fileRepository.findBySourceIdAndPath(sourceId, "photos"))
             .thenReturn(Optional.of(folderEntry));
 
         // When

--- a/archivum-server/src/test/java/tech/zaisys/archivum/server/service/FileServiceTest.java
+++ b/archivum-server/src/test/java/tech/zaisys/archivum/server/service/FileServiceTest.java
@@ -517,4 +517,107 @@ class FileServiceTest {
         verify(fileRepository).findById(fileId);
         verify(fileRepository, never()).findBySha256(any());
     }
+
+    @Test
+    void testMarkFolderAsIgnored_CascadesAndSkipsAlreadyIgnored() {
+        // Given - one file under the folder already ignored, one not
+        ScannedFile alreadyIgnored = ScannedFile.builder()
+            .id(UUID.randomUUID())
+            .source(testSource)
+            .path("photos/old.jpg")
+            .ignoreForMigration(true)
+            .build();
+        ScannedFile toIgnore = ScannedFile.builder()
+            .id(UUID.randomUUID())
+            .source(testSource)
+            .path("photos/new.jpg")
+            .ignoreForMigration(false)
+            .build();
+
+        when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(testSource));
+        when(fileRepository.findBySourceAndPathStartingWith(testSource, "photos/"))
+            .thenReturn(new ArrayList<>(List.of(alreadyIgnored, toIgnore)));
+        when(fileRepository.findBySourceAndPath(testSource, "photos"))
+            .thenReturn(Optional.empty());
+
+        // When
+        int count = fileService.markFolderAsIgnored(sourceId, "photos");
+
+        // Then - only the not-yet-ignored file is flipped and saved
+        assertEquals(1, count);
+        assertTrue(toIgnore.getIgnoreForMigration());
+        verify(fileRepository).save(toIgnore);
+        verify(fileRepository, never()).save(alreadyIgnored);
+    }
+
+    @Test
+    void testMarkFolderAsIgnored_IncludesFolderEntryItself() {
+        // Given - the folder path also exists as a file entry
+        ScannedFile folderEntry = ScannedFile.builder()
+            .id(UUID.randomUUID())
+            .source(testSource)
+            .path("photos")
+            .ignoreForMigration(false)
+            .build();
+
+        when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(testSource));
+        when(fileRepository.findBySourceAndPathStartingWith(testSource, "photos/"))
+            .thenReturn(new ArrayList<>());
+        when(fileRepository.findBySourceAndPath(testSource, "photos"))
+            .thenReturn(Optional.of(folderEntry));
+
+        // When
+        int count = fileService.markFolderAsIgnored(sourceId, "photos");
+
+        // Then
+        assertEquals(1, count);
+        assertTrue(folderEntry.getIgnoreForMigration());
+        verify(fileRepository).save(folderEntry);
+    }
+
+    @Test
+    void testMarkFolderAsIgnored_SourceNotFound() {
+        // Given
+        when(sourceRepository.findById(sourceId)).thenReturn(Optional.empty());
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class,
+            () -> fileService.markFolderAsIgnored(sourceId, "photos"));
+        verify(fileRepository, never()).save(any());
+    }
+
+    @Test
+    void testGetIgnoredFiles_ReturnsMappedDtos() {
+        // Given
+        ScannedFile ignored1 = ScannedFile.builder()
+            .id(UUID.randomUUID()).source(testSource).path("a.jpg")
+            .ignoreForMigration(true).build();
+        ScannedFile ignored2 = ScannedFile.builder()
+            .id(UUID.randomUUID()).source(testSource).path("b.jpg")
+            .ignoreForMigration(true).build();
+
+        when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(testSource));
+        when(fileRepository.findBySourceAndIgnoreForMigration(testSource, true))
+            .thenReturn(List.of(ignored1, ignored2));
+        when(fileMapper.toDto(ignored1)).thenReturn(FileDto.builder().id(ignored1.getId()).build());
+        when(fileMapper.toDto(ignored2)).thenReturn(FileDto.builder().id(ignored2.getId()).build());
+
+        // When
+        List<FileDto> result = fileService.getIgnoredFiles(sourceId);
+
+        // Then
+        assertEquals(2, result.size());
+        verify(fileRepository).findBySourceAndIgnoreForMigration(testSource, true);
+    }
+
+    @Test
+    void testGetIgnoredFiles_SourceNotFound() {
+        // Given
+        when(sourceRepository.findById(sourceId)).thenReturn(Optional.empty());
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class,
+            () -> fileService.getIgnoredFiles(sourceId));
+        verify(fileRepository, never()).findBySourceAndIgnoreForMigration(any(), anyBoolean());
+    }
 }


### PR DESCRIPTION
## Summary

`main` did not compile: `archivum-server` failed to build because `FileService` (the V019 *ignore-for-migration* feature) called three `ScannedFileRepository` methods that were never declared. This PR unbreaks the build, adds the missing coverage, enables integration tests that had never run, and fixes a real defect one of them caught.

## What's in here

**1. Fix the broken build** (`5db3319`)
- Add the three missing derived-query methods to `ScannedFileRepository` (+ `Source` import). No logic change to `FileService`.
- Add coverage that was missing (which is how the break reached `main`): real-DB Testcontainers tests for the queries, and `FileService` unit tests for `markFolderAsIgnored` / `getIgnoredFiles`.
- Make `ScannedFileRepositoryTest` actually runnable — it had never executed (no Docker in prior environments), so it didn't assign entity ids (`ScannedFile` uses caller-assigned UUIDs, no `@GeneratedValue`) and was missing an `entityManager.clear()` before a post-delete read.

**2. Enable Docker-gated integration tests + fix `source_type` default bug** (`ea903e6`)
- Three `@Disabled("Requires Docker")` Testcontainers classes now run. One caught a **real production bug**: `SourceService.createSource` passed `request.getSourceScanType()` straight to the builder, so a null request value overrode the entity's `@Builder.Default` and Hibernate persisted an explicit `null` (a DB `DEFAULT` only applies when the column is omitted from INSERT). Sources created without an explicit type got `source_type = null` instead of `DISCOVERY`, which would misroute migration planning. Fixed by defaulting to `DISCOVERY` when the request value is null.
- `FolderZoneRepositoryTest`: switched `ddl-auto` `create-drop` → `validate` so it exercises the real Flyway schema (under `create-drop`, Hibernate generated the `folder_zone` FK without the `ON DELETE CASCADE` that lives only in Flyway V007, so the cascade test failed against a schema that didn't match production).

**3. Refresh PLAN.md** (`7d540b0`) — it was ~8 months stale (tracked only the Scanner MVP). Now reflects the delivered server, UI, and Migration System, and notes the JDK 21 build requirement.

**4. Self-review cleanups** (`6090fcb`) — remove a redundant repository method, tighten a boundary test, use an import instead of an inline FQN, drop stale `TODO` comments.

## Testing

Full clean build across all modules, Testcontainers backed by a local container runtime: **265 tests, 0 skipped, 0 failures**.

> [!NOTE]
> The Testcontainers tests need a Docker-compatible socket. With rootless **podman**: `systemctl --user enable --now podman.socket`, then run with `DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock` and `TESTCONTAINERS_RYUK_DISABLED=true`. Without it they **silently skip** — CI should set this so the container tests actually run.

## Not included / follow-ups
- The V019 ignore-for-migration feature is still **unwired end to end** — no REST endpoint, and `MigrationPlanningService` doesn't read the flag. This PR only makes it compile + tested.
- Existing `source_type = null` rows (if any were already created by the bug) are **not** backfilled — no data migration here by request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjfnVNoFyohr3kr23gMGek